### PR TITLE
[V33] Telekom bearer token: Additional secret

### DIFF
--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -185,6 +185,7 @@ class UpsertProvider extends Base {
 			->addOption('clientsecret-file', null, InputOption::VALUE_REQUIRED, 'File that contains the OpenID client secret')
 			->addOption('clientsecret-env', null, InputOption::VALUE_REQUIRED, 'Environment variable that contains the OpenID client secret')
 			->addOption('discoveryuri', 'd', InputOption::VALUE_REQUIRED, 'OpenID discovery endpoint uri')
+			->addOption('bearersecret', 'bs', InputOption::VALUE_OPTIONAL, 'Telekom bearer token requires a different client secret for bearer tokens')
 			->addOption('endsessionendpointuri', 'e', InputOption::VALUE_REQUIRED, 'OpenID end session endpoint uri')
 			->addOption('postlogouturi', 'p', InputOption::VALUE_REQUIRED, 'Post logout URI')
 			->addOption('scope', 'o', InputOption::VALUE_OPTIONAL, 'OpenID requested value scopes, if not set defaults to "openid email profile"');
@@ -217,10 +218,17 @@ class UpsertProvider extends Base {
 			return $this->listProviders($input, $output);
 		}
 
+		// bearersecret is usually base64 encoded, but SAM delivers it non-encoded by default
+		// so always encode/decode for this field
+		$bearersecret = $input->getOption('bearersecret');
+		if ($bearersecret !== null) {
+			$bearersecret = $this->crypto->encrypt($this->base64UrlEncode($bearersecret));
+		}
+
 		// check if any option for updating is provided
 		$updateOptions = array_filter($input->getOptions(), static function ($value, $option) {
 			return in_array($option, [
-				'identifier', 'clientid', 'clientsecret', 'discoveryuri', 'endsessionendpointuri', 'postlogouturi', 'scope',
+				'identifier', 'clientid', 'clientsecret', 'discoveryuri', 'endsessionendpointuri', 'postlogouturi', 'scope', 'bearersecret',
 				...array_keys(self::EXTRA_OPTIONS),
 			]) && $value !== null;
 		}, ARRAY_FILTER_USE_BOTH);
@@ -261,7 +269,7 @@ class UpsertProvider extends Base {
 		}
 		try {
 			$provider = $this->providerMapper->createOrUpdateProvider(
-				$identifier, $clientId, $clientSecret, $discoveryuri, $scope, $endsessionendpointuri, $postLogoutUri
+				$identifier, $clientid, $clientsecret, $discoveryuri, $scope, $endsessionendpointuri, $postLogoutUri, $bearersecret
 			);
 			// invalidate JWKS cache (even if it was just created)
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE, '');
@@ -316,6 +324,10 @@ class UpsertProvider extends Base {
 		$table->setRows($providers);
 		$table->render();
 		return 0;
+	}
+
+	private function base64UrlEncode(string $data): string {
+		return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
 	}
 
 	private function getClientSecretInput(

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -269,7 +269,7 @@ class UpsertProvider extends Base {
 		}
 		try {
 			$provider = $this->providerMapper->createOrUpdateProvider(
-				$identifier, $clientid, $clientsecret, $discoveryuri, $scope, $endsessionendpointuri, $postLogoutUri, $bearersecret
+				$identifier, $clientId, $clientSecret, $discoveryuri, $scope, $endsessionendpointuri, $postLogoutUri, $bearersecret
 			);
 			// invalidate JWKS cache (even if it was just created)
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE, '');

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -101,7 +101,7 @@ class SettingsController extends OCSController {
 	 */
 	#[PasswordConfirmationRequired]
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['user_oidc_settings'])]
-	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint,
+	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint, string $bearerSecret,
 		array $settings = [], string $scope = 'openid email profile', ?string $endSessionEndpoint = null,
 		?string $postLogoutUri = null): DataResponse {
 		if ($this->providerService->getProviderByIdentifier($identifier) !== null) {
@@ -126,6 +126,8 @@ class SettingsController extends OCSController {
 		$provider->setEndSessionEndpoint($endSessionEndpoint ?: null);
 		$provider->setPostLogoutUri($postLogoutUri ?: null);
 		$provider->setScope($scope);
+		$encryptedBearerSecret = $this->crypto->encrypt($this->base64UrlEncode($bearerSecret));
+		$provider->setBearerSecret($encryptedBearerSecret);
 		$provider = $this->providerMapper->insert($provider);
 
 		$providerSettings = $this->providerService->setSettings($provider->getId(), $settings);
@@ -153,7 +155,7 @@ class SettingsController extends OCSController {
 	 */
 	#[PasswordConfirmationRequired]
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['user_oidc_settings'])]
-	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, ?string $clientSecret = null,
+	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, ?string $clientSecret = null, ?string $bearerSecret = null,
 		array $settings = [], string $scope = 'openid email profile', ?string $endSessionEndpoint = null,
 		?string $postLogoutUri = null): DataResponse {
 		$provider = $this->providerMapper->getProvider($providerId);
@@ -176,6 +178,9 @@ class SettingsController extends OCSController {
 		if ($clientSecret) {
 			$encryptedClientSecret = $this->crypto->encrypt($clientSecret);
 			$provider->setClientSecret($encryptedClientSecret);
+		}
+		if ($bearerSecret) {
+			$provider->setBearerSecret($this->base64UrlEncode($bearerSecret));
 		}
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
 		$provider->setEndSessionEndpoint($endSessionEndpoint ?: null);
@@ -277,5 +282,9 @@ class SettingsController extends OCSController {
 			}
 		}
 		return new DataResponse([]);
+	}
+
+	private function base64UrlEncode(string $data): string {
+		return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
 	}
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -180,7 +180,8 @@ class SettingsController extends OCSController {
 			$provider->setClientSecret($encryptedClientSecret);
 		}
 		if ($bearerSecret) {
-			$provider->setBearerSecret($this->base64UrlEncode($bearerSecret));
+			$encryptedBearerSecret = $this->crypto->encrypt($this->base64UrlEncode($bearerSecret));
+			$provider->setBearerSecret($encryptedBearerSecret);
 		}
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
 		$provider->setEndSessionEndpoint($endSessionEndpoint ?: null);

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -23,6 +23,9 @@ use OCP\AppFramework\Db\Entity;
  * @method \void setEndSessionEndpoint(?string $endSessionEndpoint)
  * @method \string|\null getPostLogoutUri()
  * @method \void setPostLogoutUri(?string $postLogoutUri)
+ * @method string getBearerSecret()
+ * @method void setBearerSecret(string $bearerSecret)
+ * @method string getScope()
  * @method \void setScope(string $scope)
  */
 class Provider extends Entity implements \JsonSerializable {
@@ -39,6 +42,8 @@ class Provider extends Entity implements \JsonSerializable {
 	protected $endSessionEndpoint;
 	/** @var string */
 	protected $postLogoutUri;
+	/** @var string */
+	protected $bearerSecret;
 	/** @var string */
 	protected $scope;
 

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -75,14 +75,14 @@ class ProviderMapper extends QBMapper {
 	 * @throws MultipleObjectsReturnedException
 	 */
 	public function createOrUpdateProvider(
-		string $identifier,
+		?string $identifier = null,
 		?string $clientId = null,
 		?string $clientSecret = null,
 		?string $discoveryUri = null,
 		string $scope = 'openid email profile',
-		?string $bearersecret = null,
 		?string $endSessionEndpointUri = null,
 		?string $postLogoutUri = null,
+		?string $bearersecret = null,
 	): Provider {
 		try {
 			$provider = $this->findProviderByIdentifier($identifier);

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -80,6 +80,7 @@ class ProviderMapper extends QBMapper {
 		?string $clientSecret = null,
 		?string $discoveryUri = null,
 		string $scope = 'openid email profile',
+		?string $bearersecret = null,
 		?string $endSessionEndpointUri = null,
 		?string $postLogoutUri = null,
 	): Provider {
@@ -102,6 +103,9 @@ class ProviderMapper extends QBMapper {
 			if ($postLogoutUri !== null) {
 				$provider->setPostLogoutUri($postLogoutUri);
 			}
+			if ($bearersecret !== null) {
+				$provider->setBearerSecret($bearersecret);
+			}
 			$provider->setScope($scope);
 
 			return $this->update($provider);
@@ -118,6 +122,7 @@ class ProviderMapper extends QBMapper {
 			$provider->setDiscoveryEndpoint($discoveryUri);
 			$provider->setEndSessionEndpoint($endSessionEndpointUri);
 			$provider->setPostLogoutUri($postLogoutUri);
+			$provider->setBearerSecret($bearersecret ?? '');
 			$provider->setScope($scope);
 
 			return $this->insert($provider);

--- a/lib/Migration/Version00008Date20211114183344.php
+++ b/lib/Migration/Version00008Date20211114183344.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version00008Date20211114183344 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('user_oidc_providers');
+		$table->addColumn('bearer_secret', 'string', [
+			'notnull' => true,
+			'length' => 64,
+		]);
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version010304Date20230902125945.php
+++ b/lib/Migration/Version010304Date20230902125945.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright 2023, Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author B. Rederlechner <bernd.rederlechner@t-systems.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Security\ICrypto;
+
+class Version010304Date20230902125945 extends SimpleMigrationStep {
+
+	/**
+	 * @var IDBConnection
+	 */
+	private $connection;
+	/**
+	 * @var ICrypto
+	 */
+	private $crypto;
+
+	public function __construct(
+		IDBConnection $connection,
+		ICrypto $crypto,
+	) {
+		$this->connection = $connection;
+		$this->crypto = $crypto;
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$tableName = 'user_oidc_providers';
+
+		if ($schema->hasTable($tableName)) {
+			$table = $schema->getTable($tableName);
+			if ($table->hasColumn('bearer_secret')) {
+				$column = $table->getColumn('bearer_secret');
+				$column->setLength(512);
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$tableName = 'user_oidc_providers';
+
+		// update secrets in user_oidc_providers and user_oidc_id4me
+		$qbUpdate = $this->connection->getQueryBuilder();
+		$qbUpdate->update($tableName)
+			->set('bearer_secret', $qbUpdate->createParameter('updateSecret'))
+			->where(
+				$qbUpdate->expr()->eq('id', $qbUpdate->createParameter('updateId'))
+			);
+
+		$qbSelect = $this->connection->getQueryBuilder();
+		$qbSelect->select('id', 'bearer_secret')
+			->from($tableName);
+		$req = $qbSelect->executeQuery();
+		while ($row = $req->fetch()) {
+			$id = $row['id'];
+			$secret = $row['bearer_secret'];
+			$encryptedSecret = $this->crypto->encrypt($secret);
+			$qbUpdate->setParameter('updateSecret', $encryptedSecret, IQueryBuilder::PARAM_STR);
+			$qbUpdate->setParameter('updateId', $id, IQueryBuilder::PARAM_INT);
+			$qbUpdate->executeStatement();
+		}
+		$req->closeCursor();
+	}
+}

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -32,6 +32,15 @@
 				:required="!update"
 				autocomplete="off">
 		</p>
+		<p>
+			<label for="oidc-bearer-secret">{{ t('user_oidc', 'Bearer shared secret') }}</label>
+			<input id="oidc-bearer-secret"
+				v-model="localProvider.bearerSecret"
+				:placeholder="update ? t('user_oidc', 'Leave empty to keep existing') : null"
+				type="text"
+				:required="!update"
+				autocomplete="off">
+		</p>
 		<p class="settings-hint warning-hint">
 			<AlertOutlineIcon :size="20" class="icon" />
 			{{ t('user_oidc', 'Warning, if the protocol of the URLs in the discovery content is HTTP, the ID token will be delivered through an insecure connection.') }}

--- a/tests/unit/MagentaCloud/BearerSettingsTest.php
+++ b/tests/unit/MagentaCloud/BearerSettingsTest.php
@@ -1,0 +1,420 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 T-Systems International
+ *
+ * @author Bernd Rederlechner <bernd.rederlechner@t-systems.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+use OCA\UserOIDC\AppInfo\Application;
+use OCA\UserOIDC\Command\UpsertProvider;
+
+use OCA\UserOIDC\Db\Provider;
+
+use OCA\UserOIDC\Db\ProviderMapper;
+use OCA\UserOIDC\Service\ProviderService;
+use OCP\IConfig;
+
+use OCP\IRequest;
+
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\TestCase;
+
+
+use Symfony\Component\Console\Tester\CommandTester;
+
+class BearerSettingsTest extends TestCase {
+	/**
+	 * @var ProviderService
+	 */
+	private $provider;
+
+	/**
+	 * @var IConfig;
+	 */
+	private $config;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$app = new \OCP\AppFramework\App(Application::APP_ID);
+		$this->requestMock = $this->createMock(IRequest::class);
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->providerMapper = $this->createMock(ProviderMapper::class);
+		$providers = [
+			new \OCA\UserOIDC\Db\Provider(),
+		];
+		$providers[0]->setId(1);
+		$providers[0]->setIdentifier('Fraesbook');
+
+		$this->providerMapper->expects(self::any())
+			->method('getProviders')
+			->willReturn($providers);
+
+		$this->providerService = $this->getMockBuilder(ProviderService::class)
+			->setConstructorArgs([ $this->config, $this->providerMapper])
+			->onlyMethods(['getProviderByIdentifier'])
+			->getMock();
+		$this->crypto = $app->getContainer()->get(ICrypto::class);
+	}
+
+	protected function mockCreateUpdate(
+		string $providername,
+		?string $clientid,
+		?string $clientsecret,
+		?string $discovery,
+		string $scope,
+		?string $bearersecret,
+		array $options,
+		int $id = 2,
+	) {
+		$provider = $this->getMockBuilder(Provider::class)
+			->addMethods(['getIdentifier', 'getId'])
+			->getMock();
+		$provider->expects($this->any())
+			->method('getIdentifier')
+			->willReturn($providername);
+		$provider->expects($this->any())
+			->method('getId')
+			->willReturn($id);
+
+		$this->providerMapper->expects($this->once())
+			->method('createOrUpdateProvider')
+			->with(
+				$this->equalTo($providername),
+				$this->equalTo($clientid),
+				$this->anything(),
+				$this->equalTo($discovery),
+				$this->equalTo($scope),
+				$this->anything()
+			)
+			->willReturnCallback(function ($id, $clientid, $secret, $discovery, $scope, $bsecret) use ($clientsecret, $bearersecret, $provider) {
+				if ($secret !== null) {
+					$this->assertEquals($clientsecret, $this->crypto->decrypt($secret));
+				} else {
+					$this->assertNull($secret);
+				}
+				if ($bsecret !== null) {
+					$this->assertEquals($bearersecret, \Base64Url\Base64Url::decode($this->crypto->decrypt($bsecret)));
+				} else {
+					$this->assertNull($bsecret);
+				}
+				return $provider;
+			});
+
+
+		$this->config->expects($this->any())
+			->method('setAppValue')
+			->with($this->equalTo(Application::APP_ID), $this->anything(), $this->anything())
+			->willReturnCallback(function ($appid, $key, $value) use ($options) {
+				if (array_key_exists($key, $options)) {
+					$this->assertEquals($options[$key], $value);
+				}
+				return '';
+			});
+	}
+
+
+	public function testCommandAddProvider() {
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn(null);
+
+		$this->mockCreateUpdate('Telekom',
+			'10TVL0SAM30000004901NEXTMAGENTACLOUDTEST',
+			'clientsecret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'openid email profile',
+			'bearersecret***',
+			[
+				'provider-2-' . ProviderService::SETTING_UNIQUE_UID => '0',
+				'provider-2-' . ProviderService::SETTING_MAPPING_DISPLAYNAME => 'urn:telekom.com:displayname',
+				'provider-2-' . ProviderService::SETTING_MAPPING_EMAIL => 'urn:telekom.com:mainEmail',
+				'provider-2-' . ProviderService::SETTING_MAPPING_QUOTA => 'quota',
+				'provider-2-' . ProviderService::SETTING_MAPPING_UID => 'sub'
+			]);
+
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--clientid' => '10TVL0SAM30000004901NEXTMAGENTACLOUDTEST',
+			'--clientsecret' => 'clientsecret***',
+			'--bearersecret' => 'bearersecret***',
+			'--discoveryuri' => 'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'--scope' => 'openid email profile',
+			'--unique-uid' => '0',
+			'--mapping-display-name' => 'urn:telekom.com:displayname',
+			'--mapping-email' => 'urn:telekom.com:mainEmail',
+			'--mapping-quota' => 'quota',
+			'--mapping-uid' => 'sub',
+		]);
+
+
+		//$output = $commandTester->getOutput();
+		//$this->assertContains('done', $output);
+	}
+
+	protected function mockProvider(string $providername,
+		string $clientid,
+		string $clientsecret,
+		string $discovery,
+		string $scope,
+		string $bearersecret,
+		int $id = 2) : Provider {
+		$provider = $this->getMockBuilder(Provider::class)
+			->addMethods(['getIdentifier', 'getClientId', 'getClientSecret', 'getBearerSecret', 'getDiscoveryEndpoint'])
+			->setMethods(['getScope', 'getId'])
+			->getMock();
+		$provider->expects($this->any())
+			->method('getIdentifier')
+			->willReturn($providername);
+		$provider->expects($this->any())
+			->method('getId')
+			->willReturn(2);
+		$provider->expects($this->any())
+			->method('getClientId')
+			->willReturn($clientid);
+		$provider->expects($this->any())
+			->method('getClientSecret')
+			->willReturn($clientsecret);
+		$provider->expects($this->any())
+			->method('getBearerSecret')
+			->willReturn(\Base64Url\Base64Url::encode($bearersecret));
+		$provider->expects($this->any())
+			->method('getDiscoveryEndpoint')
+			->willReturn($discovery);
+		$provider->expects($this->any())
+			->method('getScope')
+			->willReturn($scope);
+										
+		return $provider;
+	}
+
+	public function testCommandUpdateFull() {
+		$provider = $this->getMockBuilder(Provider::class)
+			->addMethods(['getIdentifier', 'getClientId', 'getClientSecret', 'getBearerSecret', 'getDiscoveryEndpoint'])
+			->setMethods(['getScope'])
+			->getMock();
+		$provider->expects($this->any())
+			->method('getIdentifier')
+			->willReturn('Telekom');
+		$provider->expects($this->never())->method('getClientId');
+		$provider->expects($this->never())->method('getClientSecret');
+		$provider->expects($this->never())->method('getBearerSecret');
+		$provider->expects($this->never())->method('getDiscoveryEndpoint');
+		$provider->expects($this->never())->method('getScope');
+
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn(null);
+		$this->mockCreateUpdate('Telekom',
+			'10TVL0SAM30000004902NEXTMAGENTACLOUDTEST',
+			'client*secret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-unknown/openid-configuration',
+			'openid profile',
+			'bearer*secret***',
+			[
+				'provider-2-' . ProviderService::SETTING_UNIQUE_UID => '1',
+				'provider-2-' . ProviderService::SETTING_MAPPING_DISPLAYNAME => 'urn:telekom.com:displaykrame',
+				'provider-2-' . ProviderService::SETTING_MAPPING_EMAIL => 'urn:telekom.com:mainDemail',
+				'provider-2-' . ProviderService::SETTING_MAPPING_QUOTA => 'quotas',
+				'provider-2-' . ProviderService::SETTING_MAPPING_UID => 'flop'
+			]);
+
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--clientid' => '10TVL0SAM30000004902NEXTMAGENTACLOUDTEST',
+			'--clientsecret' => 'client*secret***',
+			'--bearersecret' => 'bearer*secret***',
+			'--discoveryuri' => 'https://accounts.login00.idm.ver.sul.t-online.de/.well-unknown/openid-configuration',
+			'--scope' => 'openid profile',
+			'--mapping-display-name' => 'urn:telekom.com:displaykrame',
+			'--mapping-email' => 'urn:telekom.com:mainDemail',
+			'--mapping-quota' => 'quotas',
+			'--mapping-uid' => 'flop',
+			'--unique-uid' => '1'
+		]);
+	}
+
+	public function testCommandUpdateSingleClientId() {
+		$provider = $this->mockProvider('Telekom', '10TVL0SAM30000004901NEXTMAGENTACLOUDTEST', 'clientsecret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'openid email profile', 'bearersecret***');
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn($provider);
+		$this->mockCreateUpdate(
+			'Telekom',
+			'10TVL0SAM30000004903NEXTMAGENTACLOUDTEST',
+			null,
+			null,
+			'openid email profile',
+			null,
+			[]);
+
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--clientid' => '10TVL0SAM30000004903NEXTMAGENTACLOUDTEST',
+		]);
+	}
+
+
+	public function testCommandUpdateSingleClientSecret() {
+		$provider = $this->mockProvider('Telekom', '10TVL0SAM30000004901NEXTMAGENTACLOUDTEST', 'clientsecret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'openid email profile', 'bearersecret***');
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn($provider);
+		$this->mockCreateUpdate(
+			'Telekom',
+			null,
+			'***clientsecret***',
+			null,
+			'openid email profile',
+			null,
+			[]);
+ 
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--clientsecret' => '***clientsecret***',
+		]);
+	}
+
+	public function testCommandUpdateSingleBearerSecret() {
+		$provider = $this->mockProvider('Telekom', '10TVL0SAM30000004901NEXTMAGENTACLOUDTEST', 'clientsecret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'openid email profile', 'bearersecret***');
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn($provider);
+		$this->mockCreateUpdate(
+			'Telekom',
+			null,
+			null,
+			null,
+			'openid email profile',
+			'***bearersecret***',
+			[]);
+ 
+
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--bearersecret' => '***bearersecret***',
+		]);
+	}
+
+	public function testCommandUpdateSingleDiscoveryEndpoint() {
+		$provider = $this->mockProvider('Telekom', '10TVL0SAM30000004901NEXTMAGENTACLOUDTEST', 'clientsecret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'openid email profile', 'bearersecret***');
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn($provider);
+		$this->mockCreateUpdate(
+			'Telekom',
+			null,
+			null,
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-unknown/openid-configuration',
+			'openid email profile',
+			null, []);
+
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--discoveryuri' => 'https://accounts.login00.idm.ver.sul.t-online.de/.well-unknown/openid-configuration',
+		]);
+	}
+
+	public function testCommandUpdateSingleScope() {
+		$provider = $this->mockProvider('Telekom', '10TVL0SAM30000004901NEXTMAGENTACLOUDTEST', 'clientsecret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'openid email profile', 'bearersecret***');
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn($provider);
+		$this->mockCreateUpdate(
+			'Telekom',
+			null,
+			null,
+			null,
+			'openid profile',
+			'***bearersecret***',
+			[]);
+ 
+
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--scope' => 'openid profile',
+		]);
+	}
+
+	public function testCommandUpdateSingleUniqueUid() {
+		$provider = $this->mockProvider('Telekom', '10TVL0SAM30000004901NEXTMAGENTACLOUDTEST', 'clientsecret***',
+			'https://accounts.login00.idm.ver.sul.t-online.de/.well-known/openid-configuration',
+			'openid email profile', 'bearersecret***');
+		$this->providerService->expects($this->once())
+			->method('getProviderByIdentifier')
+			->with($this->equalTo('Telekom'))
+			->willReturn($provider);
+		$this->mockCreateUpdate(
+			'Telekom',
+			null,
+			null,
+			null,
+			'openid email profile',
+			null,
+			['provider-2-' . ProviderService::SETTING_UNIQUE_UID => '1']);
+ 
+		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
+		$commandTester = new CommandTester($command);
+
+		$commandTester->execute([
+			'identifier' => 'Telekom',
+			'--unique-uid' => '1',
+		]);
+	}
+}

--- a/tests/unit/MagentaCloud/BearerSettingsTest.php
+++ b/tests/unit/MagentaCloud/BearerSettingsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * @copyright Copyright (c) 2021 T-Systems International
  *
@@ -207,7 +208,7 @@ class BearerSettingsTest extends TestCase {
 		$provider->expects($this->any())
 			->method('getScope')
 			->willReturn($scope);
-										
+
 		return $provider;
 	}
 
@@ -303,7 +304,7 @@ class BearerSettingsTest extends TestCase {
 			'openid email profile',
 			null,
 			[]);
- 
+
 		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
 		$commandTester = new CommandTester($command);
 
@@ -329,7 +330,7 @@ class BearerSettingsTest extends TestCase {
 			'openid email profile',
 			'***bearersecret***',
 			[]);
- 
+
 
 		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
 		$commandTester = new CommandTester($command);
@@ -381,7 +382,7 @@ class BearerSettingsTest extends TestCase {
 			'openid profile',
 			'***bearersecret***',
 			[]);
- 
+
 
 		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
 		$commandTester = new CommandTester($command);
@@ -408,7 +409,7 @@ class BearerSettingsTest extends TestCase {
 			'openid email profile',
 			null,
 			['provider-2-' . ProviderService::SETTING_UNIQUE_UID => '1']);
- 
+
 		$command = new UpsertProvider($this->providerService, $this->providerMapper, $this->crypto);
 		$commandTester = new CommandTester($command);
 


### PR DESCRIPTION
Telekom bearer token handling requires a secret different from the OpenID Connect client secret.
Field is added with the following properties:

delivered as plain text, but internal token handling requires base64 encoding, so the field is base64 encoded/decoded internally
the secret is encrypted in the same way as all other secret information in user_oidc.
we keep the old DB migration sequence from NMC V24
this PR only contains the DB and command line changes.