### PR TITLE
[V33] Redirect after access denied error

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -1018,16 +1018,6 @@ class LoginController extends BaseOidcController {
 		);
 	}
 
-	private function toCodeChallenge(string $data): string {
-		// Basically one big work around for the base64url decode being weird
-		$h = pack('H*', hash('sha256', $data));
-		$s = base64_encode($h); // Regular base64 encoder
-		$s = explode('=', $s)[0]; // Remove any trailing '='s
-		$s = str_replace('+', '-', $s); // 62nd char of encoding
-		$s = str_replace('/', '_', $s); // 63rd char of encoding
-		return $s;
-	}
-
 	private function isMobileDevice(): bool {
 		$mobileKeywords = $this->config->getSystemValue('user_oidc.mobile_keywords', ['Android', 'iPhone', 'iPad', 'iPod', 'Windows Phone', 'Mobile', 'webOS', 'BlackBerry', 'Opera Mini', 'IEMobile']);
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -370,6 +370,11 @@ class LoginController extends BaseOidcController {
 		$this->logger->debug('Code login with core: ' . $code . ' and state: ' . $state);
 
 		if ($error !== '') {
+			if (!$this->isMobileDevice()) {
+				$cancelRedirectUrl = $this->config->getSystemValue('user_oidc.cancel_redirect_url', 'https://cloud.telekom-dienste.de/');
+				return new RedirectResponse($cancelRedirectUrl);
+			}
+
 			$this->logger->warning('Code login error', ['error' => $error, 'error_description' => $error_description]);
 			if ($this->isDebugModeEnabled()) {
 				return new JSONResponse([
@@ -1011,6 +1016,22 @@ class LoginController extends BaseOidcController {
 			],
 			Http::STATUS_BAD_REQUEST,
 		);
+	}
+
+	private function isMobileDevice(): bool {
+		$mobileKeywords = $this->config->getSystemValue('user_oidc.mobile_keywords', ['Android', 'iPhone', 'iPad', 'iPod', 'Windows Phone', 'Mobile', 'webOS', 'BlackBerry', 'Opera Mini', 'IEMobile']);
+
+		if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+			return false; // if no user-agent is set, assume desktop
+		}
+
+		foreach ($mobileKeywords as $keyword) {
+			if (stripos($_SERVER['HTTP_USER_AGENT'], $keyword) !== false) {
+				return true; // device is mobile
+			}
+		}
+
+		return false; // device is desktop
 	}
 
 	private function toCodeChallenge(string $data): string {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -1018,6 +1018,16 @@ class LoginController extends BaseOidcController {
 		);
 	}
 
+	private function toCodeChallenge(string $data): string {
+		// Basically one big work around for the base64url decode being weird
+		$h = pack('H*', hash('sha256', $data));
+		$s = base64_encode($h); // Regular base64 encoder
+		$s = explode('=', $s)[0]; // Remove any trailing '='s
+		$s = str_replace('+', '-', $s); // 62nd char of encoding
+		$s = str_replace('/', '_', $s); // 63rd char of encoding
+		return $s;
+	}
+
 	private function isMobileDevice(): bool {
 		$mobileKeywords = $this->config->getSystemValue('user_oidc.mobile_keywords', ['Android', 'iPhone', 'iPad', 'iPod', 'Windows Phone', 'Mobile', 'webOS', 'BlackBerry', 'Opera Mini', 'IEMobile']);
 


### PR DESCRIPTION
After an access denied error, the user should be forwardet to the page "https://cloud.telekom-dienste.de/".
This can happen after the user hits cancel during the login process.
Mobile clients handle this error on their own.