### PR TITLE
[V33] Backchannel logout fix

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -200,23 +200,16 @@ class LoginController extends BaseOidcController {
 			return $this->buildErrorTemplateResponse($message, Http::STATUS_NOT_FOUND, ['reason' => 'provider unreachable']);
 		}
 
-		// check if oidc state is present in session data
-		if ($this->session->exists(self::STATE)) {
-			$state = $this->session->get(self::STATE);
-			$nonce = $this->session->get(self::NONCE);
-		} else {
-			$state = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
-			$sessionKeySuffix = '-' . $state;
-			$this->session->set(self::STATE . $sessionKeySuffix, $state);
-			$this->logger->debug('Storing OIDC state', ['state' => $state]);
-			$timestamp = $this->timeFactory->getTime();
-			$this->session->set(self::TIMESTAMP . $sessionKeySuffix, $timestamp);
-			$this->session->set(self::REDIRECT_AFTER_LOGIN . $sessionKeySuffix, $redirectUrl);
+		$state = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
+		$sessionKeySuffix = '-' . $state;
+		$this->session->set(self::STATE . $sessionKeySuffix, $state);
+		$this->logger->debug('Storing OIDC state', ['state' => $state]);
+		$timestamp = $this->timeFactory->getTime();
+		$this->session->set(self::TIMESTAMP . $sessionKeySuffix, $timestamp);
+		$this->session->set(self::REDIRECT_AFTER_LOGIN . $sessionKeySuffix, $redirectUrl);
 
-			$nonce = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
-			$this->session->set(self::NONCE . $sessionKeySuffix, $nonce);
-			$this->session->set(self::PROVIDERID, $providerId);
-		}
+		$nonce = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
+		$this->session->set(self::NONCE . $sessionKeySuffix, $nonce);
 
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
 		$isPkceSupported = in_array('S256', $discovery['code_challenge_methods_supported'] ?? [], true);
@@ -228,7 +221,7 @@ class LoginController extends BaseOidcController {
 			$this->session->set(self::CODE_VERIFIER . $sessionKeySuffix, $code_verifier);
 		}
 
-		// $this->session->set(self::LOGIN_PROVIDERID . $sessionKeySuffix, $providerId);
+		$this->session->set(self::LOGIN_PROVIDERID . $sessionKeySuffix, $providerId);
 		$this->session->close();
 
 		// get attribute mapping settings
@@ -709,10 +702,6 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $userId, null, false));
 		}
 
-		// remove code login session values
-		$this->session->remove(self::STATE);
-		$this->session->remove(self::NONCE);
-
 		// Set last password confirm to the future as we don't have passwords to confirm against with SSO
 		$this->session->set('last-password-confirm', $this->timeFactory->getTime() + 4 * 365 * 24 * 3600);
 
@@ -1018,14 +1007,9 @@ class LoginController extends BaseOidcController {
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
-	 * @BruteForceProtection(action=userOidcBackchannelLogout)
-	 *
-	 * @param string $logout_token
-	 * @return JSONResponse
-	 * @throws Exception
-	 * @throws \JsonException
+	 * @BruteForceProtection(action: 'userOidcBackchannelLogout')
 	 */
-	public function telekomBackChannelLogout(string $logout_token = '') {
+	public function telekomBackChannelLogout(string $logout_token = ''): JSONResponse {
 		return $this->backChannelLogout('Telekom', $logout_token);
 	}
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -709,17 +709,6 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $userId, null, false));
 		}
 
-		// $storeLoginTokenEnabled = $this->appConfig->getValueString(Application::APP_ID, 'store_login_token', '0') === '1';
-		// if ($storeLoginTokenEnabled) {
-			// store all token information for potential token exchange requests
-			// $tokenData = array_merge(
-			// 	$data,
-			// 	['provider_id' => $providerId],
-			// );
-			// $this->tokenService->storeToken($tokenData);
-		// }
-		// $this->config->setUserValue($user->getUID(), Application::APP_ID, 'had_token_once', '1');
-
 		// remove code login session values
 		$this->session->remove(self::STATE);
 		$this->session->remove(self::NONCE);

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -83,8 +83,8 @@ class LoginController extends BaseOidcController {
 	// this id token is used to send id_token_hint to the IdP logout endpoint
 	private const ID_TOKEN = 'oidc.id_token';
 
-	// we consider that a login flow should complete within 5 minutes
-	private const LOGIN_FLOW_TIMEOUT = 300;
+	// we consider that a login flow should complete within 6 minutes
+	private const LOGIN_FLOW_TIMEOUT = 360;
 
 	public function __construct(
 		IRequest $request,

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -1002,17 +1002,6 @@ class LoginController extends BaseOidcController {
 		);
 	}
 
-	/**
-	 * Backward compatible function for MagentaCLOUD to smoothly transition to new config
-	 *
-	 * @PublicPage
-	 * @NoCSRFRequired
-	 * @BruteForceProtection(action: 'userOidcBackchannelLogout')
-	 */
-	public function telekomBackChannelLogout(string $logout_token = ''): JSONResponse {
-		return $this->backChannelLogout('Telekom', $logout_token);
-	}
-
 	private function toCodeChallenge(string $data): string {
 		// Basically one big work around for the base64url decode being weird
 		$h = pack('H*', hash('sha256', $data));
@@ -1033,5 +1022,16 @@ class LoginController extends BaseOidcController {
 		$this->session->remove(self::REDIRECT_AFTER_LOGIN . $sessionKeySuffix);
 		$this->session->remove(self::CODE_VERIFIER . $sessionKeySuffix);
 		$this->session->remove(self::TIMESTAMP . $sessionKeySuffix);
+	}
+
+	/**
+	 * Backward compatible function for MagentaCLOUD to smoothly transition to new config
+	 *
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @BruteForceProtection(action: 'userOidcBackchannelLogout')
+	 */
+	public function telekomBackChannelLogout(string $logout_token = ''): JSONResponse {
+		return $this->backChannelLogout('Telekom', $logout_token);
 	}
 }

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -200,16 +200,23 @@ class LoginController extends BaseOidcController {
 			return $this->buildErrorTemplateResponse($message, Http::STATUS_NOT_FOUND, ['reason' => 'provider unreachable']);
 		}
 
-		$state = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
-		$sessionKeySuffix = '-' . $state;
-		$this->session->set(self::STATE . $sessionKeySuffix, $state);
-		$this->logger->debug('Storing OIDC state', ['state' => $state]);
-		$timestamp = $this->timeFactory->getTime();
-		$this->session->set(self::TIMESTAMP . $sessionKeySuffix, $timestamp);
-		$this->session->set(self::REDIRECT_AFTER_LOGIN . $sessionKeySuffix, $redirectUrl);
+		// check if oidc state is present in session data
+		if ($this->session->exists(self::STATE)) {
+			$state = $this->session->get(self::STATE);
+			$nonce = $this->session->get(self::NONCE);
+		} else {
+			$state = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
+			$sessionKeySuffix = '-' . $state;
+			$this->session->set(self::STATE . $sessionKeySuffix, $state);
+			$this->logger->debug('Storing OIDC state', ['state' => $state]);
+			$timestamp = $this->timeFactory->getTime();
+			$this->session->set(self::TIMESTAMP . $sessionKeySuffix, $timestamp);
+			$this->session->set(self::REDIRECT_AFTER_LOGIN . $sessionKeySuffix, $redirectUrl);
 
-		$nonce = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
-		$this->session->set(self::NONCE . $sessionKeySuffix, $nonce);
+			$nonce = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
+			$this->session->set(self::NONCE . $sessionKeySuffix, $nonce);
+			$this->session->set(self::PROVIDERID, $providerId);
+		}
 
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
 		$isPkceSupported = in_array('S256', $discovery['code_challenge_methods_supported'] ?? [], true);
@@ -221,7 +228,7 @@ class LoginController extends BaseOidcController {
 			$this->session->set(self::CODE_VERIFIER . $sessionKeySuffix, $code_verifier);
 		}
 
-		$this->session->set(self::LOGIN_PROVIDERID . $sessionKeySuffix, $providerId);
+		// $this->session->set(self::LOGIN_PROVIDERID . $sessionKeySuffix, $providerId);
 		$this->session->close();
 
 		// get attribute mapping settings
@@ -702,16 +709,20 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $userId, null, false));
 		}
 
-		$storeLoginTokenEnabled = $this->appConfig->getValueString(Application::APP_ID, 'store_login_token', '0', lazy: true) === '1';
-		if ($storeLoginTokenEnabled) {
+		// $storeLoginTokenEnabled = $this->appConfig->getValueString(Application::APP_ID, 'store_login_token', '0') === '1';
+		// if ($storeLoginTokenEnabled) {
 			// store all token information for potential token exchange requests
-			$tokenData = array_merge(
-				$data,
-				['provider_id' => $providerId],
-			);
-			$this->tokenService->storeToken($tokenData);
-		}
-		$this->config->setUserValue($user->getUID(), Application::APP_ID, 'had_token_once', '1');
+			// $tokenData = array_merge(
+			// 	$data,
+			// 	['provider_id' => $providerId],
+			// );
+			// $this->tokenService->storeToken($tokenData);
+		// }
+		// $this->config->setUserValue($user->getUID(), Application::APP_ID, 'had_token_once', '1');
+
+		// remove code login session values
+		$this->session->remove(self::STATE);
+		$this->session->remove(self::NONCE);
 
 		// Set last password confirm to the future as we don't have passwords to confirm against with SSO
 		$this->session->set('last-password-confirm', $this->timeFactory->getTime() + 4 * 365 * 24 * 3600);
@@ -720,7 +731,7 @@ class LoginController extends BaseOidcController {
 		try {
 			$authToken = $this->authTokenProvider->getToken($this->session->getId());
 			$this->sessionMapper->createOrUpdateSession(
-				$idTokenPayload->sid ?? 'fallback-sid',
+				$idTokenPayload->{'urn:telekom.com:session_token'} ?? 'fallback-sid',
 				$idTokenPayload->sub ?? 'fallback-sub',
 				$idTokenPayload->iss ?? 'fallback-iss',
 				$authToken->getId(),
@@ -1011,6 +1022,22 @@ class LoginController extends BaseOidcController {
 			],
 			Http::STATUS_BAD_REQUEST,
 		);
+	}
+
+	/**
+	 * Backward compatible function for MagentaCLOUD to smoothly transition to new config
+	 *
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @BruteForceProtection(action=userOidcBackchannelLogout)
+	 *
+	 * @param string $logout_token
+	 * @return JSONResponse
+	 * @throws Exception
+	 * @throws \JsonException
+	 */
+	public function telekomBackChannelLogout(string $logout_token = '') {
+		return $this->backChannelLogout('Telekom', $logout_token);
 	}
 
 	private function toCodeChallenge(string $data): string {


### PR DESCRIPTION
We needed to switch back to Nextcloud delivered version for getting the secured version and profit from future updates.

Making it work for Telekom needs some fixes (some of that need to be contributed upstream).

We implemented also the old backchannel endpoint for silent switch in production.