### PR TITLE
[MAIN] Redirect after access denied error

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -370,6 +370,11 @@ class LoginController extends BaseOidcController {
 		$this->logger->debug('Code login with core: ' . $code . ' and state: ' . $state);
 
 		if ($error !== '') {
+			if (!$this->isMobileDevice()) {
+				$cancelRedirectUrl = $this->config->getSystemValue('user_oidc.cancel_redirect_url', 'https://cloud.telekom-dienste.de/');
+				return new RedirectResponse($cancelRedirectUrl);
+			}
+
 			$this->logger->warning('Code login error', ['error' => $error, 'error_description' => $error_description]);
 			if ($this->isDebugModeEnabled()) {
 				return new JSONResponse([
@@ -1076,6 +1081,22 @@ class LoginController extends BaseOidcController {
 		// Per RFC : https://openid.net/specs/openid-connect-backchannel-1_0.html#BCResponse
 		$response->cacheFor(0);
 		return $response;
+	}
+
+	private function isMobileDevice(): bool {
+		$mobileKeywords = $this->config->getSystemValue('user_oidc.mobile_keywords', ['Android', 'iPhone', 'iPad', 'iPod', 'Windows Phone', 'Mobile', 'webOS', 'BlackBerry', 'Opera Mini', 'IEMobile']);
+
+		if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+			return false; // if no user-agent is set, assume desktop
+		}
+
+		foreach ($mobileKeywords as $keyword) {
+			if (stripos($_SERVER['HTTP_USER_AGENT'], $keyword) !== false) {
+				return true; // device is mobile
+			}
+		}
+
+		return false; // device is desktop
 	}
 
 	private function toCodeChallenge(string $data): string {


### PR DESCRIPTION
After an access denied error, the user should be forwarded to the page "https://cloud.telekom-dienste.de/".
This can happen after the user hits cancel during the login process.
Mobile clients handle this error on their own.