### PR TITLE
[MAIN] Backchannel logout fix

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -16,6 +16,7 @@ return [
 		['name' => 'login#code', 'url' => '/code', 'verb' => 'GET'],
 		['name' => 'login#singleLogoutService', 'url' => '/sls', 'verb' => 'GET'],
 		['name' => 'login#backChannelLogout', 'url' => '/backchannel-logout/{providerIdentifier}', 'verb' => 'POST'],
+		['name' => 'login#telekomBackChannelLogout', 'url' => '/logout', 'verb' => 'POST'],
 
 		['name' => 'id4me#showLogin', 'url' => '/id4me', 'verb' => 'GET'],
 		['name' => 'id4me#login', 'url' => '/id4me', 'verb' => 'POST'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -33,7 +33,8 @@ return [
 		['name' => 'Settings#getSupportedSettings', 'url' => '/api/{apiVersion}/supported-settings', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'Settings#setAdminConfig', 'url' => '/api/{apiVersion}/admin-config', 'verb' => 'POST', 'requirements' => $requirements],
 
-		['name' => 'ocsApi#createUser', 'url' => '/api/{apiVersion}/user', 'verb' => 'POST', 'requirements' => $requirements],
-		['name' => 'ocsApi#deleteUser', 'url' => '/api/{apiVersion}/user/{userId}', 'verb' => 'DELETE', 'requirements' => $requirements],
+		// We have to disable the endpoints to avoid problems with Telekom provisioning
+		// ['name' => 'ocsApi#createUser', 'url' => '/api/{apiVersion}/user', 'verb' => 'POST', 'requirements' => $requirements],
+		// ['name' => 'ocsApi#deleteUser', 'url' => '/api/{apiVersion}/user/{userId}', 'verb' => 'DELETE', 'requirements' => $requirements],
 	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -32,9 +32,5 @@ return [
 		['name' => 'Settings#setID4ME', 'url' => '/api/{apiVersion}/provider/id4me', 'verb' => 'POST', 'requirements' => $requirements],
 		['name' => 'Settings#getSupportedSettings', 'url' => '/api/{apiVersion}/supported-settings', 'verb' => 'GET', 'requirements' => $requirements],
 		['name' => 'Settings#setAdminConfig', 'url' => '/api/{apiVersion}/admin-config', 'verb' => 'POST', 'requirements' => $requirements],
-
-		// We have to disable the endpoints to avoid problems with Telekom provisioning
-		// ['name' => 'ocsApi#createUser', 'url' => '/api/{apiVersion}/user', 'verb' => 'POST', 'requirements' => $requirements],
-		// ['name' => 'ocsApi#deleteUser', 'url' => '/api/{apiVersion}/user/{userId}', 'verb' => 'DELETE', 'requirements' => $requirements],
 	],
 ];

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -1091,11 +1091,10 @@ class LoginController extends BaseOidcController {
 
 	/**
 	 * Backward compatible function for MagentaCLOUD to smoothly transition to new config
-	 *
-	 * @PublicPage
-	 * @NoCSRFRequired
-	 * @BruteForceProtection(action: 'userOidcBackchannelLogout')
 	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[BruteForceProtection(action: 'userOidcBackchannelLogout')]
 	public function telekomBackChannelLogout(string $logout_token = ''): JSONResponse {
 		return $this->backChannelLogout('Telekom', $logout_token);
 	}

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -702,17 +702,6 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $userId, null, false));
 		}
 
-		$storeLoginTokenEnabled = $this->appConfig->getValueString(Application::APP_ID, 'store_login_token', '0', lazy: true) === '1';
-		if ($storeLoginTokenEnabled) {
-			// store all token information for potential token exchange requests
-			$tokenData = array_merge(
-				$data,
-				['provider_id' => $providerId],
-			);
-			$this->tokenService->storeToken($tokenData);
-		}
-		$this->config->setUserValue($user->getUID(), Application::APP_ID, 'had_token_once', '1');
-
 		// Set last password confirm to the future as we don't have passwords to confirm against with SSO
 		$this->session->set('last-password-confirm', $this->timeFactory->getTime() + 4 * 365 * 24 * 3600);
 
@@ -720,7 +709,7 @@ class LoginController extends BaseOidcController {
 		try {
 			$authToken = $this->authTokenProvider->getToken($this->session->getId());
 			$this->sessionMapper->createOrUpdateSession(
-				$idTokenPayload->sid ?? 'fallback-sid',
+				$idTokenPayload->{'urn:telekom.com:session_token'} ?? 'fallback-sid',
 				$idTokenPayload->sub ?? 'fallback-sub',
 				$idTokenPayload->iss ?? 'fallback-iss',
 				$authToken->getId(),
@@ -1098,5 +1087,16 @@ class LoginController extends BaseOidcController {
 		$this->session->remove(self::REDIRECT_AFTER_LOGIN . $sessionKeySuffix);
 		$this->session->remove(self::CODE_VERIFIER . $sessionKeySuffix);
 		$this->session->remove(self::TIMESTAMP . $sessionKeySuffix);
+	}
+
+	/**
+	 * Backward compatible function for MagentaCLOUD to smoothly transition to new config
+	 *
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @BruteForceProtection(action: 'userOidcBackchannelLogout')
+	 */
+	public function telekomBackChannelLogout(string $logout_token = ''): JSONResponse {
+		return $this->backChannelLogout('Telekom', $logout_token);
 	}
 }


### PR DESCRIPTION
We needed to switch back to Nextcloud delivered version for getting the secured version and profit from future updates.
Making it work for Telekom needs some fixes (some of that need to be contributed upstream).
We implemented also the old backchannel endpoint for silent switch in production.